### PR TITLE
[mytest] Fix crash ..

### DIFF
--- a/mytest.py
+++ b/mytest.py
@@ -69,6 +69,7 @@ InitFallbackFiles()
 profile("config.misc")
 config.misc.radiopic = ConfigText(default = resolveFilename(SCOPE_CURRENT_SKIN, "radio.mvi"))
 config.misc.blackradiopic = ConfigText(default = resolveFilename(SCOPE_CURRENT_SKIN, "black.mvi"))
+config.misc.useTransponderTime = ConfigYesNo(default=True)
 config.misc.SyncTimeUsing = ConfigSelection(default = "0", choices = [("0", _("Transponder time")), ("1", _("NTP"))])
 config.misc.NTPserver = ConfigText(default = 'pool.ntp.org', fixed_size=False)
 config.misc.startCounter = ConfigInteger(default=0) # number of e2 starts...


### PR DESCRIPTION
Fix crash error on system time plugin ...

<  File "/usr/lib/enigma2/python/Plugins/SystemPlugins/SystemTime/plugin.py", line 78, in __init__
<  if config.plugins.SystemTime.choiceSystemTime.value == '1' and config.misc.useTransponderTime.value:
<   File "/usr/lib/enigma2/python/Components/config.py", line 1953, in __getattr__
<   AttributeError: useTransponderTime